### PR TITLE
Add filter parameter to list endpoint

### DIFF
--- a/datahub/main.py
+++ b/datahub/main.py
@@ -35,9 +35,9 @@ def index():
 
         return jsonify(data), 200
 
-    events = redis.keys()
-
-    print(events)
+    # Return all keys matching the specified pattern
+    pattern = request.args.get('filter', '*')
+    events = redis.keys(pattern)
 
     return jsonify([
         event.decode('ascii') for event in events

--- a/tests/test_api_list.py
+++ b/tests/test_api_list.py
@@ -4,6 +4,13 @@ from tests.testcases import AppTestCase
 
 class ApiListTestCase(AppTestCase):
 
+    def add_data(self, data):
+        self.app.post(
+            self.endpoint,
+            data=json.dumps(data),
+            content_type='application/json'
+        )
+
     def test_get_empty_list(self):
         response = self.app.get(self.endpoint)
 
@@ -12,20 +19,31 @@ class ApiListTestCase(AppTestCase):
 
     def test_get_list(self):
         for i in range(1, 4):
-            self.app.post(
-                self.endpoint,
-                data=json.dumps({
-                    'name': 'Name %s' % i,
-                    'value': i
-                }),
-                content_type='application/json'
-            )
+            self.add_data({
+                'name': 'Name %s' % i,
+                'value': i
+            })
 
         response = self.app.get(self.endpoint)
 
         self.assertEqual(response.status_code, 200)
-
         self.assertEqual(len(response.json), 3)
         self.assertIn('Name 1', response.json)
         self.assertIn('Name 2', response.json)
         self.assertIn('Name 3', response.json)
+
+    def test_filter_by_pattern(self):
+        self.add_data({
+            'name': 'sensor:temperature',
+            'value': 64
+        })
+        self.add_data({
+            'name': 'event:face_recognized',
+            'value': 64
+        })
+
+        response = self.app.get(self.endpoint + '?filter=sensor:*')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json), 1)
+        self.assertIn('sensor:temperature', response.json)


### PR DESCRIPTION
This allows patterns to be passed to redis via the `filter` url parameter.

Closes #13